### PR TITLE
Temporary counters fix

### DIFF
--- a/src/com/mishiranu/dashchan/content/service/WatcherService.java
+++ b/src/com/mishiranu/dashchan/content/service/WatcherService.java
@@ -35,6 +35,7 @@ import android.os.Handler;
 import android.os.IBinder;
 import android.os.Message;
 import android.os.Process;
+import android.os.SystemClock;
 
 import chan.content.ChanConfiguration;
 import chan.content.ChanManager;
@@ -468,6 +469,7 @@ public class WatcherService extends Service implements FavoritesStorage.Observer
 		@Override
 		public Result call() {
 			WatcherItem watcherItem = result.watcherItem;
+			SystemClock.sleep(500);
 			try {
 				ChanPerformer performer = ChanPerformer.get(watcherItem.chanName);
 				ChanPerformer.ReadPostsCountResult result = performer.safe()


### PR DESCRIPTION
Счётчики не показывались из-за того что добавили какое-то ебучее ограничение, и нигде об этом не написали. Клиент посылает много запросов, а сервер отдаёт 503. Надо добавить величину этой задержки в расширение, чтобы другие борды не работали так медленно. 